### PR TITLE
Add binder reqs and badge to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,9 @@ Seabird
 .. image:: https://img.shields.io/pypi/v/seabird.svg
         :target: https://pypi.python.org/pypi/seabird
 
+.. image:: https://mybinder.org/badge_logo.svg
+        :target: https://mybinder.org/v2/gh/castelao/seabird/master?filepath=docs%2Fnotebooks%2FBasicsReadingData.ipynb
+
 
 This is a parser for Sea Bird CTD and TSG output files.
 

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,13 @@
+name: seabird-env
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python
+  - gsw==3.2.1
+  - numpy==1.15.4
+  - pandas==0.23.4
+  - matplotlib==3.0.2
+  - seaborn==0.9.0
+  - pip:
+    - -e ..

--- a/docs/notebooks/ProcessingData.ipynb
+++ b/docs/notebooks/ProcessingData.ipynb
@@ -72,7 +72,7 @@
     }
    ],
    "source": [
-    "!wget https://raw.githubusercontent.com/castelao/seabird/master/tests/data/CTD/dPIRX003.cnv"
+    "!wget https://raw.githubusercontent.com/castelao/seabird/master/sampledata/CTD/dPIRX003.cnv"
    ]
   },
   {
@@ -118,8 +118,8 @@
     }
    ],
    "source": [
-    "print \"Header: %s\" % profile.attributes.keys()\n",
-    "print \"Data: %s\" % profile.keys()"
+    "print(\"Header: %s\" % profile.attributes.keys())\n",
+    "print(\"Data: %s\" % profile.keys())"
    ]
   },
   {


### PR DESCRIPTION
Since #47 was merged, why not make this repo available on mybinder.org? =]

Example: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/castelao/seabird/binder?filepath=docs%2Fnotebooks%2FBasicsReadingData.ipynb)

I also fixed `docs/notebooks/ProcessingData.ipynb` to make it run in Python 3.