### PR TITLE
add start datetime to as_DataFrame method

### DIFF
--- a/seabird/cnv.py
+++ b/seabird/cnv.py
@@ -499,6 +499,8 @@ class CNV(object):
         output = pd.DataFrame(output)
         output['LATITUDE'] = self.attrs['LATITUDE']
         output['LONGITUDE'] = self.attrs['LONGITUDE']
+        if "datetime" in self.attrs.keys():   
+            output['datetime_first_scan'] = self.attrs['datetime']
 
         return output
 


### PR DESCRIPTION
as_DataFrame did not copy any datetime information to the created dataframe. This checks that the attribute `start_time` exists; if so, it creates a column in the dataframe the same fashion as lon and lat.

Name `datetime_first_scan` chosen as I believe this is the timestamp from the first scan of the cast.

This commit fixes #60 