### PR TITLE
change 'attrs' key to 'attributes'

### DIFF
--- a/seabird/cnv.py
+++ b/seabird/cnv.py
@@ -175,8 +175,8 @@ class CNV(object):
         refnames = json.loads(text.decode('utf-8'), encoding="utf-8")
         # ---- Parse fields
 
-        if ('attrs' in self.rule) and \
-                (self.rule['attrs']['instrument_type'] == 'CTD-bottle'):
+        if ('attributes' in self.rule) and \
+                (self.rule['attributes']['instrument_type'] == 'CTD-bottle'):
                     rule = r"""
                       \s+ Bottle \s+ Date .* \n
                       \s+ Position \s+ Time .* \n


### PR DESCRIPTION
change key from 'attrs' to 'attributes' to correctly load btl files 

current behaviour (5a268309dc6b281243bfb59a6722743f895ac47e):
calling fCNV with example btl file fails:
```
dat = seabird.fCNV("seabird\sampledata\btl\MI18MHDR.btl")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\Me\src\fork\seabird\seabird\cnv.py", line 574, in __init__
    super(fCNV, self).__init__(text, defaults)
  File "C:\Users\Me\src\fork\seabird\seabird\cnv.py", line 81, in __init__
    self.load_bottledata()
  File "C:\Users\Me\src\fork\seabird\seabird\cnv.py", line 306, in load_bottledata
    attrs = self.data[0].attrs
IndexError: list index out of range
```

behaviour with merge: 
calling fCNV with example btl file is successful
```
dat = seabird.fCNV("seabird\sampledata\btl\MI18MHDR.btl")
dat
<seabird.cnv.fCNV object at 0x0000023393BE9908>
dat.ids
[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
```
