### PR TITLE
Fix JSON load, bottle data and cnv2nc output

### DIFF
--- a/seabird/cnv.py
+++ b/seabird/cnv.py
@@ -561,7 +561,7 @@ class CNV(object):
             for k in self.keys():
                 if len(self[k]) != nvalues:
                     module_logger.warning(
-                        ("\033[91m%s was supposed to has %s values, "
+                        ("\033[91m%s was supposed to have %s values, "
                         "but found only %s.\033[0m") %
                         (k, nvalues, len(self[k])))
 

--- a/seabird/cnv.py
+++ b/seabird/cnv.py
@@ -138,6 +138,16 @@ class CNV(object):
                     self.attrs['instrument_type'] = 'CTD'
                 elif self.attrs['sbe_model'] in ['21', '45']:
                     self.attrs['instrument_type'] = 'TSG'
+        
+        # Get Notes
+        if 'notes' in  self.parsed:
+            self.attrs['notes'] = self.parsed['notes']
+
+            # Add notes ("<key>: <value>") as a global attribute
+            if 'notes' in self.parsed:
+                pattern = re.compile("\\*\\*\\ (?P<key>\\w*?)\\:\\ *(?P<value>.*?)\\r?\\n\r", re.VERBOSE)
+                for key, value in pattern.findall(self.parsed['notes']):
+                        self.attrs[key.lower()] = value
 
     def get_attrs(self):
         """

--- a/seabird/cnv.py
+++ b/seabird/cnv.py
@@ -138,16 +138,7 @@ class CNV(object):
                     self.attrs['instrument_type'] = 'CTD'
                 elif self.attrs['sbe_model'] in ['21', '45']:
                     self.attrs['instrument_type'] = 'TSG'
-        
-        # Get Notes
-        if 'notes' in  self.parsed:
-            self.attrs['notes'] = self.parsed['notes']
 
-            # Add notes ("<key>: <value>") as a global attribute
-            if 'notes' in self.parsed:
-                pattern = re.compile("\\*\\*\\ (?P<key>\\w*?)\\:\\ *(?P<value>.*?)\\r?\\n\r", re.VERBOSE)
-                for key, value in pattern.findall(self.parsed['notes']):
-                        self.attrs[key.lower()] = value
 
     def get_attrs(self):
         """

--- a/seabird/cnv.py
+++ b/seabird/cnv.py
@@ -181,8 +181,8 @@ class CNV(object):
                       \s+ Bottle \s+ Date .* \n
                       \s+ Position \s+ Time .* \n
                     """
-                    attrib_text = re.search(r"""\n \s+ Bottle \s+ Date \s+ (.*) \s*\r?\n \s+ Position \s+ Time""", self.parsed['header'], re.VERBOSE).group(1)
-                    pattern = re.compile(r"""(?P<varname>[-|+|\w|\.|/]+)""", re.VERBOSE)
+                    attrib_text = re.search(r"""\n \s+ Bottle \s+ Date(.*)\s*\r?\n \s+ Position \s+ Time""", self.parsed['header'], re.VERBOSE).group(1)
+                    pattern = re.compile(r"""(?P<varname>.{11})""", re.VERBOSE)
 
                     self.ids = [0, 1, 2]
                     self.data = [ma.array([]), ma.array([]), ma.array([])]
@@ -200,11 +200,11 @@ class CNV(object):
                         self.ids.append(len(self.ids))
                         self.data.append(ma.array([]))
                         try:
-                            reference = refnames[x.groupdict()['varname']]
+                            reference = refnames[x.groupdict()['varname'].lstrip()]
                             varname = reference['name']
                             #longname = reference['longname']
                         except:
-                            varname = x.groupdict()['varname']
+                            varname = x.groupdict()['varname'].lstrip()
                         self.data[-1].attrs = {
                                 'id': self.ids[-1],
                                 'name': varname,

--- a/seabird/cnv.py
+++ b/seabird/cnv.py
@@ -182,7 +182,7 @@ class CNV(object):
         # ----
         rule_file = "rules/refnames.json"
         text = pkg_resources.resource_string(__name__, rule_file)
-        refnames = json.loads(text.decode('utf-8'), encoding="utf-8")
+        refnames = json.loads(text.decode('utf-8'))
         # ---- Parse fields
 
         if ('attributes' in self.rule) and \

--- a/seabird/cnv.py
+++ b/seabird/cnv.py
@@ -352,6 +352,11 @@ class CNV(object):
             self.ids.append(id)
             self.data.append(ma.array(values))
             attrs = self.data[nvars - nvars_std + std_id].attrs.copy()
+            # Ignore fields that are stats specific
+            ignore_attributes = ['sdn_parameter_urn','sdn_parameter_name']
+            attrs = {key:value for key,value in attrs.items() if key not in ignore_attributes}
+            if "long_name" in attrs:
+                attrs['long_name'] += " Standard Deviation"
             attrs["cell_method"] = "scan: standard_deviation"
             attrs["name"] += '_sdev'
             # Scan count per bottle if available

--- a/seabird/cnv.py
+++ b/seabird/cnv.py
@@ -23,6 +23,7 @@ from numpy import ma
 from seabird.exceptions import CNVError
 from seabird.utils import load_rule
 
+logging.basicConfig(level='INFO', format='%(message)s')
 module_logger = logging.getLogger('seabird.cnv')
 
 

--- a/seabird/cnv.py
+++ b/seabird/cnv.py
@@ -175,8 +175,8 @@ class CNV(object):
         refnames = json.loads(text.decode('utf-8'), encoding="utf-8")
         # ---- Parse fields
 
-        if ('attrs' in self.rule) and \
-                (self.rule['attrs']['instrument_type'] == 'CTD-bottle'):
+        if ('attributes' in self.rule) and \
+                (self.rule['attributes']['instrument_type'] == 'CTD-bottle'):
                     rule = r"""
                       \s+ Bottle \s+ Date .* \n
                       \s+ Position \s+ Time .* \n

--- a/seabird/cnv.py
+++ b/seabird/cnv.py
@@ -305,6 +305,12 @@ class CNV(object):
         content = self.raw_data()['bottledata']
         nvars = len(self.ids)
         data_std = {}
+        def _convert(x):
+            if '.' in x:
+                return float(x)
+            else:
+                return int(x)
+                
         for rec in re.finditer(self.rule['data'], content, re.VERBOSE):
             attrs = self.data[0].attrs
             self.data[0] = np.append(self.data[0],
@@ -324,14 +330,16 @@ class CNV(object):
             for n, v in enumerate(re.findall('[-|+|\w|\.]+',
                                   rec.groupdict()['values']),
                                   start=3):
+                v = _convert(v)
                 attrs = self.data[n].attrs
-                self.data[n] = np.append(self.data[n], v)
+                self.data[n] = np.append(self.data[n],v)
                 self.data[n].attrs = attrs
 
             #Add std values
             for n, v in enumerate(re.findall('[-|+|\w|\.]+',
                                 rec.groupdict()['values_std']),
                                 start=0):
+                v = _convert(v)
                 if n in data_std:
                     data_std[n] = np.append(data_std[n], v)
                 else:

--- a/seabird/cnv.py
+++ b/seabird/cnv.py
@@ -343,7 +343,7 @@ class CNV(object):
             self.data.append(ma.array(values))
             attrs = self.data[nvars - nvars_std + std_id].attrs.copy()
             attrs["cell_method"] = "scan: standard_deviation"
-            attrs["name"] += '_std'
+            attrs["name"] += '_sdev'
             # Scan count per bottle if available
             if 'scan_per_bottle' in self.attrs:
                 attrs["cell_method"] += " (previous " + self.attrs["scan_per_bottle"] + " scans)"

--- a/seabird/cnv.py
+++ b/seabird/cnv.py
@@ -23,7 +23,6 @@ from numpy import ma
 from seabird.exceptions import CNVError
 from seabird.utils import load_rule
 
-logging.basicConfig(format='%(message)s',level=logging.INFO)
 module_logger = logging.getLogger('seabird.cnv')
 
 

--- a/seabird/cnv.py
+++ b/seabird/cnv.py
@@ -23,6 +23,7 @@ from numpy import ma
 from seabird.exceptions import CNVError
 from seabird.utils import load_rule
 
+logging.basicConfig(format='%(message)s',level=logging.INFO)
 module_logger = logging.getLogger('seabird.cnv')
 
 
@@ -97,7 +98,7 @@ class CNV(object):
         for d in self.data:
             if d.attrs['name'] == key:
                 return d
-        raise KeyError('%s not found' % key)
+        logging.error('%s not found' % key)
 
     @property
     def attributes(self):

--- a/seabird/netcdf.py
+++ b/seabird/netcdf.py
@@ -51,6 +51,7 @@ def cnv2nc(data, filename):
             "\033[91mATENTION The data suggest '%s' records are available while the header suggest '%s' records]."
             % (real_values, data.attributes["nvalues"])
         )
+    nc.createDimension("scan", len(data[data.keys()[0]]))
 
     logging.info("\nVariabes")
     cdf_variables = {}

--- a/seabird/netcdf.py
+++ b/seabird/netcdf.py
@@ -30,7 +30,7 @@ def cnv2nc(data, filename):
 
     nc.history = "Created by cnv2nc (PyCNV)"
 
-    nc.DATE_CREATION = datetime.now().strftime("%Y%m%d%H%M%S")
+    nc.date_created = datetime.now().isoformat()
 
     # print "Global attributes"
     A = sorted(data.attrs.keys())

--- a/seabird/netcdf.py
+++ b/seabird/netcdf.py
@@ -56,7 +56,11 @@ def cnv2nc(data, filename):
                     k.decode('utf8', 'ignore'), 'd', ('scan',))
             print("\033[91mATENTION, I need to ignore the non UTF-8 "
                   "characters in '%s' to create the netCDF file.\033[0m" % k)
-        cdf_variables[k].missing_value = data[k].fill_value
+        
+        # Ignore unknown fill_value
+        if data[k].fill_value not in ['?','N/A'] :
+            cdf_variables[k].missing_value = data[k].fill_value
+
         for a in data[k].attrs.keys():
             print("\t\033[93m%s\033[0m: %s" % (a, data[k].attrs[a]))
             # cdf_variables[k].__setattr__(a, data[k].attrs[a])

--- a/seabird/netcdf.py
+++ b/seabird/netcdf.py
@@ -42,11 +42,8 @@ def cnv2nc(data, filename):
                 nc.__setattr__(a, data.attrs[a])
         except:
             module_logger.warning("Problems with %s" % a)
-    
-    if 'nvalues' in data.attrs:
-        nc.createDimension('scan', int(data.attrs['nvalues']))
-    else:
-        nc.createDimension('scan', len(data[data.keys()[0]]))
+
+    nc.createDimension('scan', len(data[data.keys()[0]]))
 
     print("\nVariabes")
     cdf_variables = {}

--- a/seabird/netcdf.py
+++ b/seabird/netcdf.py
@@ -43,6 +43,9 @@ def cnv2nc(data, filename):
         except:
             module_logger.warning("Problems with %s" % a)
 
+    real_values = len(data[data.keys()[0]])
+    if     real_values != int(data.attributes['nvalues']):
+        print("\033[91mATENTION The data suggest '%s' records are available while the header suggest '%s' records." % (real_values, data.attributes['nvalues']))
     nc.createDimension('scan', len(data[data.keys()[0]]))
 
     print("\nVariabes")
@@ -55,6 +58,12 @@ def cnv2nc(data, filename):
             string_length = len(str_values[0])
             cdf_variables[k] = nc.createVariable(k, 'S' + str(string_length), ('scan',))
             cdf_variables[k][:] = str_values
+            continue
+
+        if k in cdf_variables:
+            print("\033[91mATENTION The duplicated variables are not"
+            " compatible with the NetCDF Format. "
+            "The very first variable '%s' will be considered." % k)
             continue
 
         try:

--- a/seabird/netcdf.py
+++ b/seabird/netcdf.py
@@ -69,10 +69,12 @@ def cnv2nc(data, filename):
         try:
             cdf_variables[k] = nc.createVariable(k, 'd', ('scan',))
         except:
+            ik = k
+            k = k.replace('/','Per')
             cdf_variables[k] = nc.createVariable(
-                    k.decode('utf8', 'ignore'), 'd', ('scan',))
+                    k, 'd', ('scan',))
             print("\033[91mATENTION, I need to ignore the non UTF-8 "
-                  "characters in '%s' to create the netCDF file.\033[0m" % k)
+                  "characters in '%s' by '%s' to create the netCDF file.\033[0m" % (ik,k))
         
         # Ignore unknown fill_value
         if data[k].fill_value not in ['?','N/A'] :

--- a/seabird/netcdf.py
+++ b/seabird/netcdf.py
@@ -39,8 +39,11 @@ def cnv2nc(data, filename):
             nc.__setattr__(a, data.attrs[a])
         except:
             module_logger.warning("Problems with %s" % a)
-
-    nc.createDimension('scan', int(data.attrs['nvalues']))
+    
+    if 'nvalues' in data.attrs:
+        nc.createDimension('scan', int(data.attrs['nvalues']))
+    else:
+        nc.createDimension('scan', len(data[data.keys()[0]]))
 
     print("\nVariabes")
     cdf_variables = {}

--- a/seabird/rules/cnv_btl.json
+++ b/seabird/rules/cnv_btl.json
@@ -17,7 +17,8 @@
         "start_time": "\\#\\ start_time\\ =\\ (?P<value>.*?)\\r?\\n      # Should work, but I'm not happy with this.\n",
         "bad_flag": "\\#\\ bad_flag\\ =\\ (?P<value>.*?)\\s\n",
         "file_type": "\\#\\ file_type\\ \\=\\ (?P<value>.*?)\\r?\\n\n",
-        "awkward_xml": "(?P<value>\n  \\#\\ \\<\\?xml\\ version=\"\\d+\\.\\d+\"\\ encoding=\"UTF-8\"\\?>\\r?\\n\n  (?:\\#\\s+<.*>\\r?\\n)+\n)\n"
+        "awkward_xml": "(?P<value>\n  \\#\\ \\<\\?xml\\ version=\"\\d+\\.\\d+\"\\ encoding=\"UTF-8\"\\?>\\r?\\n\n  (?:\\#\\s+<.*>\\r?\\n)+\n)\n",
+        "scan_per_bottle": "\\#\\ datcnv_scans_per_bottle\\ \\=\\ (?P<value>.*)\n"
     },
 "fieldname": "\\#\\ name\\ (?P<id>\\d+)\\ =\\ (?P<name>.*)\\:(?:\\ (?P<longname>.*))?\\r?\\s\n",
 "fieldspan": "\\#\\ span\\ (?P<id>\\d+)\\ =\\ (?P<valuemin>.*),\\ (?P<valuemax>.*)\\r?\\s\n",

--- a/seabird/rules/cnv_btl.json
+++ b/seabird/rules/cnv_btl.json
@@ -9,7 +9,9 @@
         "LATITUDE": "\\*\\ NMEA\\ Latitude\\ =\\ (?P<value>.*?)\\r?\\n\n",
         "LONGITUDE": "\\*\\ NMEA\\ Longitude\\ =\\ (?P<value>.*?)\\r?\\n\n",
         "gps_datetime": "\\*\\ NMEA\\ UTC\\ \\(Time\\)\\ =\\ (?P<value>.*?)\\r?\\n\n",
-        "seasave": "\\*\\ Software\\ Version\\ Seasave\\ (?P<value>.*?)\\r?\\n\n"
+        "seasave": "\\*\\ Software\\ Version\\ Seasave\\ (?P<value>.*?)\\r?\\n\n",
+        "temperature_sn": "\\*\\ Temperature\\ SN\\ =\\ (?P<value>\\d*?)\\r?\\n\r",
+        "conductivity_sn": "\\*\\ Conductivity\\ SN\\ =\\ (?P<value>\\d*?)\\r?\\n\r"
     },
 "descriptors": {
         "nquan": "\\#\\ nquan\\ =\\ (?P<value>\\d+)\n",
@@ -18,7 +20,8 @@
         "bad_flag": "\\#\\ bad_flag\\ =\\ (?P<value>.*?)\\s\n",
         "file_type": "\\#\\ file_type\\ \\=\\ (?P<value>.*?)\\r?\\n\n",
         "awkward_xml": "(?P<value>\n  \\#\\ \\<\\?xml\\ version=\"\\d+\\.\\d+\"\\ encoding=\"UTF-8\"\\?>\\r?\\n\n  (?:\\#\\s+<.*>\\r?\\n)+\n)\n",
-        "scan_per_bottle": "\\#\\ datcnv_scans_per_bottle\\ \\=\\ (?P<value>.*)\n"
+        "scan_per_bottle": "\\#\\ datcnv_scans_per_bottle\\ \\=\\ (?P<value>.*)\n",
+        "history": "\\#\\ \\<\\/Sensors\\>\\n(?P<value>(.|\\n)*)Bottle"
     },
 "fieldname": "\\#\\ name\\ (?P<id>\\d+)\\ =\\ (?P<name>.*)\\:(?:\\ (?P<longname>.*))?\\r?\\s\n",
 "fieldspan": "\\#\\ span\\ (?P<id>\\d+)\\ =\\ (?P<valuemin>.*),\\ (?P<valuemax>.*)\\r?\\s\n",

--- a/seabird/rules/cnv_btl.json
+++ b/seabird/rules/cnv_btl.json
@@ -8,10 +8,7 @@
         "sbe_model": "\\*\\ Sea-Bird\\ SBE\\ +(?P<value>\\d.*)\\ Data\\ File:\\r?\\n",
         "LATITUDE": "\\*\\ NMEA\\ Latitude\\ =\\ (?P<value>.*?)\\r?\\n\n",
         "LONGITUDE": "\\*\\ NMEA\\ Longitude\\ =\\ (?P<value>.*?)\\r?\\n\n",
-        "gps_datetime": "\\*\\ NMEA\\ UTC\\ \\(Time\\)\\ =\\ (?P<value>.*?)\\r?\\n\n",
-        "seasave": "\\*\\ Software\\ Version\\ Seasave\\ (?P<value>.*?)\\r?\\n\n",
-        "temperature_sn": "\\*\\ Temperature\\ SN\\ =\\ (?P<value>\\d*?)\\r?\\n\r",
-        "conductivity_sn": "\\*\\ Conductivity\\ SN\\ =\\ (?P<value>\\d*?)\\r?\\n\r"
+        "gps_datetime": "\\*\\ NMEA\\ UTC\\ \\(Time\\)\\ =\\ (?P<value>.*?)\\r?\\n\n"
     },
 "descriptors": {
         "nquan": "\\#\\ nquan\\ =\\ (?P<value>\\d+)\n",
@@ -19,9 +16,7 @@
         "start_time": "\\#\\ start_time\\ =\\ (?P<value>.*?)\\r?\\n      # Should work, but I'm not happy with this.\n",
         "bad_flag": "\\#\\ bad_flag\\ =\\ (?P<value>.*?)\\s\n",
         "file_type": "\\#\\ file_type\\ \\=\\ (?P<value>.*?)\\r?\\n\n",
-        "awkward_xml": "(?P<value>\n  \\#\\ \\<\\?xml\\ version=\"\\d+\\.\\d+\"\\ encoding=\"UTF-8\"\\?>\\r?\\n\n  (?:\\#\\s+<.*>\\r?\\n)+\n)\n",
-        "scan_per_bottle": "\\#\\ datcnv_scans_per_bottle\\ \\=\\ (?P<value>.*)\n",
-        "history": "\\#\\ \\<\\/Sensors\\>\\n(?P<value>(.|\\n)*)Bottle"
+        "awkward_xml": "(?P<value>\n  \\#\\ \\<\\?xml\\ version=\"\\d+\\.\\d+\"\\ encoding=\"UTF-8\"\\?>\\r?\\n\n  (?:\\#\\s+<.*>\\r?\\n)+\n)\n"
     },
 "fieldname": "\\#\\ name\\ (?P<id>\\d+)\\ =\\ (?P<name>.*)\\:(?:\\ (?P<longname>.*))?\\r?\\s\n",
 "fieldspan": "\\#\\ span\\ (?P<id>\\d+)\\ =\\ (?P<valuemin>.*),\\ (?P<valuemax>.*)\\r?\\s\n",

--- a/seabird/rules/cnv_btl.json
+++ b/seabird/rules/cnv_btl.json
@@ -8,7 +8,8 @@
         "sbe_model": "\\*\\ Sea-Bird\\ SBE\\ +(?P<value>\\d.*)\\ Data\\ File:\\r?\\n",
         "LATITUDE": "\\*\\ NMEA\\ Latitude\\ =\\ (?P<value>.*?)\\r?\\n\n",
         "LONGITUDE": "\\*\\ NMEA\\ Longitude\\ =\\ (?P<value>.*?)\\r?\\n\n",
-        "gps_datetime": "\\*\\ NMEA\\ UTC\\ \\(Time\\)\\ =\\ (?P<value>.*?)\\r?\\n\n"
+        "gps_datetime": "\\*\\ NMEA\\ UTC\\ \\(Time\\)\\ =\\ (?P<value>.*?)\\r?\\n\n",
+        "seasave": "\\*\\ Software\\ Version\\ Seasave\\ (?P<value>.*?)\\r?\\n\n"
     },
 "descriptors": {
         "nquan": "\\#\\ nquan\\ =\\ (?P<value>\\d+)\n",

--- a/seabird/utils.py
+++ b/seabird/utils.py
@@ -74,7 +74,7 @@ def load_rule(raw_text):
     for rule_file in rule_files:
         text = pkg_resources.resource_string(
                 __name__, os.path.join(rules_dir, rule_file))
-        rule = json.loads(text.decode('utf-8'), encoding="utf-8")
+        rule = json.loads(text.decode('utf-8'))
         # Should I load using codec, for UTF8?? Do I need it?
         # f = codecs.open(rule_file, 'r', 'utf-8')
         # rule = yaml.load(f.read())


### PR DESCRIPTION
This present PR address a few different issues related to the seabird package
## Issues
### JSON.loads encoding input with python >3.7
- **json.loads encoding**: Python >3.7 json.loads method to not accept the deprecated encoding input.  [The input encoding should be UTF-8, UTF-16 or UTF-32.](https://docs.python.org/3.8/library/json.html#json.loads). To resolve the issue, the `encoding `input is removed from the different `json.loads` commands. see related issue #65 
### .btl files parsing
- replace typo `attrs` by `attributes` in prepare_data method specific to bottle file data. Similar to PR#62, see also issue #66
- **split btl table header by 11 characters**: Seabird btl file columns use a fix-width (11 characters). The original regex was separating the columns by white spaces which failed in some cases since some Seabird variable names are 11 character wide, leaving no white space between two columns. See issue #41
- **extract sdev values from btl files**: If a btl file contains standard deviation data, the tool will add those variables to the dataset by considering matching parameters starting from the right of the table to the left.
- **scan_per_bottle**: Retrieve scan_per_bottle attribute from btl file's header
### Move print to logging
All print methods are converted to `logging.[info,warning,error]` inputs.
### cnv2nc method improvement
- **ouput attributes to netcdf output**: this code was originally commented. Variable attributes are added to the outputted NetCDF file with the attributes "name" and empty ones ignored.
- Convert datetime format attributes to String Format 
- Convert datetime format variables to String Format 
- Rename attributes to CF compliant equivalent
- Replace `/` character in variables  names by `Per` to be compatible with NetCDF.
- Set dimension length based on length values within the data (not header `nvalues`)
- Add warning if `nvalues!= len(data)`
